### PR TITLE
Add setup.py with console_script to allow for shell command installation

### DIFF
--- a/scare.py
+++ b/scare.py
@@ -183,7 +183,7 @@ def parseCmd(cmd, smu):
 
     return shouldAssemble
 
-if __name__ == '__main__':
+def main():
     printSplash("cerulean")
     args = parser.parse_args()
     print("Type / for help\n")
@@ -238,3 +238,6 @@ if __name__ == '__main__':
                     currentAddr = sConfig["emu/baseaddr"]
         except EOFError:
             break
+
+if __name__ == '__main__':
+    main()

--- a/setup.py
+++ b/setup.py
@@ -8,11 +8,11 @@ setuptools.setup(
     license="GPLv2",
     license_files=["LICENSE.md"],
     classifiers=["License :: OSI Approved :: GNU General Public License v2 (GPLv2)"],
-    requires=["unicorn", "keystone", "capstone"],
+    install_requires=["unicorn", "keystone-engine", "capstone"],
     py_modules=["scare"],
     entry_points={
         "console_scripts": [
-            "scare = scare",
+            "scare = scare:main",
         ]
     },
 )

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,18 @@
+import setuptools
+
+setuptools.setup(
+    name="scare",
+    version="0.3.0",
+    description="scare is a multi-arch assembly REPL and emulator for your command line.",
+    author="netspooky",
+    license="GPLv2",
+    license_files=["LICENSE.md"],
+    classifiers=["License :: OSI Approved :: GNU General Public License v2 (GPLv2)"],
+    requires=["unicorn", "keystone", "capstone"],
+    py_modules=["scare"],
+    entry_points={
+        "console_scripts": [
+            "scare = scare",
+        ]
+    },
+)


### PR DESCRIPTION
Thanks for the release! I expect to use it in a range of projects and I'm lazy, so I took the liberty of writing a simple setup.py to allow for a pip install.

It's quite minimal and I got the information from the source (version and license), please let me know if something is wrong.

I tried not to touch any core code, but I had to add a `__main__` and a `main()` function in `scare.py` so I could call it from the console. I hope that's not an issue.