### PR TITLE
Add windows compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 keystone-engine
 unicorn
 capstone
+pyreadline3

--- a/scare.py
+++ b/scare.py
@@ -2,7 +2,11 @@
 from __future__ import print_function
 import time
 import sys
-import readline
+try:
+    import readline
+except Exception:
+    from pyreadline3 import Readline
+    readline = Readline()
 import argparse
 from scarelib import *
 


### PR DESCRIPTION
Readline isn't meant to work on windows, but this can be fixed by using pyreadline3 as found in [this](https://stackoverflow.com/questions/51157443/pythons-readline-module-not-available-for-windows) stack overflow post, I've also updated requirements to make this work as well. 